### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
Potential fix for [https://github.com/outshift-open/open-ui-kit/security/code-scanning/5](https://github.com/outshift-open/open-ui-kit/security/code-scanning/5)

To fix this problem, an explicit `permissions` key should be added to the workflow at the top level, limiting the default rights granted to the `GITHUB_TOKEN`. Since none of the jobs (lint, format, build, storybook build) need write access to any repository resource, `contents: read` is the suitable minimal permission. This should be inserted after the `name` field but before the `on` block at the top of the YAML file, which will apply to all jobs in the workflow and satisfy least privilege requirements. No further code or dependency changes are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
