### PR TITLE
fix: breadcrumbs separator icon color

### DIFF
--- a/packages/open-ui-kit/src/components/breadcrumbs/components/breadcrumbs.tsx
+++ b/packages/open-ui-kit/src/components/breadcrumbs/components/breadcrumbs.tsx
@@ -64,10 +64,10 @@ export const Breadcrumbs = ({
       aria-label="breadcrumb"
       separator={
         <ChevronRightIcon
-          color={color}
           sx={{
             width: "20px",
             height: "20px",
+            color: theme.palette.vars.interactiveSecondaryDefaultDefault,
           }}
         />
       }


### PR DESCRIPTION
## 📝 Description

- fix breadcrumbs separator icon color, to be visible in both themes

## 🧪 Type of Change

<!-- Check all that apply -->
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🎨 Style/design update
- [ ] 🔧 Build/CI update
- [ ] ♻️ Refactoring (no functional changes)
- [ ] 🧪 Tests only


## 🔍 Additional Notes

<!-- Any additional information, context, or notes for reviewers -->

---

**For Maintainers:**
- [x] Ready for review
- [ ] Requires design review
- [ ] Requires accessibility review
- [x] Ready to merge