### PR TITLE
feat(responsivity)!: Extend breakpoints' list

### DIFF
--- a/packages/open-ui-kit/src/charts/bar-graph/bar-graph.tsx
+++ b/packages/open-ui-kit/src/charts/bar-graph/bar-graph.tsx
@@ -68,17 +68,20 @@ export const BarGraph = ({
 
   const [header0, header1] = headers;
 
-  const updateYAxisWidth = () => {
-    if (chartContainerRef.current) {
-      const chartWidth =
-        chartContainerRef.current.getBoundingClientRect().width;
-      setYAxisWidth(chartWidth * 0.43);
-    }
-  };
-
   useEffect(() => {
+    const el = chartContainerRef.current;
+    if (!el) return;
+
+    const updateYAxisWidth = () => {
+      const chartWidth = el.getBoundingClientRect().width;
+      setYAxisWidth(chartWidth * 0.43);
+    };
+
     updateYAxisWidth();
-    window.addEventListener("resize", updateYAxisWidth, false);
+
+    const ro = new ResizeObserver(updateYAxisWidth);
+    ro.observe(el);
+    return () => ro.disconnect();
   }, []);
 
   return (
@@ -177,7 +180,6 @@ export const BarGraph = ({
           spacing={2}
           alignItems="center"
           overflow="hidden"
-          position="absolute"
           bottom={0}
           sx={{
             backgroundColor: theme.palette.vars.interactiveSecondaryWeakDefault,

--- a/packages/open-ui-kit/src/components/modal/stories/modal.stories.tsx
+++ b/packages/open-ui-kit/src/components/modal/stories/modal.stories.tsx
@@ -39,6 +39,12 @@ const meta: Meta<typeof Modal> = {
       ),
     },
   },
+  argTypes: {
+    maxWidth: {
+      description:
+        "Dialog **content width** preset (MUI). This string is **not** the same as layout viewport breakpoints (`theme.breakpoints`). See the **Dialog sizes** story and `docs/new-breakpoints-branch-changes.md`.",
+    },
+  },
 };
 
 export default meta;
@@ -97,11 +103,32 @@ export const SimpleModal: Story = {
 };
 
 export const DialogSizes: Story = {
+  name: "Dialog sizes (content width)",
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Labels use M / L / XL (content) to avoid confusing these with layout breakpoints. Engineers still set MUI maxWidth (md / lg / xl) as shown in each row. Mapping: theme/mui/dialog.tsx docblock and docs/new-breakpoints-branch-changes.md.",
+      },
+    },
+  },
   render: () => (
     <Stack gap={2}>
-      <ModalComponent maxWidth="md" fullWidth title="md" />
-      <ModalComponent maxWidth="lg" fullWidth title="lg" />
-      <ModalComponent maxWidth="xl" fullWidth title="xl" />
+      <ModalComponent
+        maxWidth="md"
+        fullWidth
+        title='M (content), maxWidth="md", 600px paper'
+      />
+      <ModalComponent
+        maxWidth="lg"
+        fullWidth
+        title='L (content), maxWidth="lg", 1024px paper'
+      />
+      <ModalComponent
+        maxWidth="xl"
+        fullWidth
+        title='XL (content), maxWidth="xl", 1440px paper'
+      />
     </Stack>
   ),
 };

--- a/packages/open-ui-kit/src/components/overflow-tooltip/components/overflow-tooltip.tsx
+++ b/packages/open-ui-kit/src/components/overflow-tooltip/components/overflow-tooltip.tsx
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { useState, useRef, useEffect } from "react";
+import { useState, useRef, useEffect, useCallback } from "react";
 import { rtlWrapperStyle, baseWrapperStyle, spanStyle } from "../styles";
 import { Tooltip, TooltipProps } from "@/components";
 
@@ -24,37 +24,27 @@ export const OverflowTooltip = ({
   styleText,
   ...rest
 }: OverflowTooltipProps) => {
-  // Create Ref
-  const textElementRef = useRef() as React.MutableRefObject<HTMLDivElement>;
+  const textElementRef = useRef<HTMLDivElement | null>(null);
+  const [hoverStatus, setHover] = useState(false);
 
-  /**
-   * Compares the size of the text element to its container and sets the hover state accordingly
-   */
-  const compareSize = () => {
-    const compare =
-      textElementRef.current.scrollWidth > textElementRef.current.clientWidth;
-    setHover(compare);
-  };
-
-  // Add resize listener to compare size on component mount
-  useEffect(() => {
-    window.addEventListener("resize", compareSize);
+  const compareSize = useCallback(() => {
+    const el = textElementRef.current;
+    if (!el) return;
+    setHover(el.scrollWidth > el.clientWidth);
   }, []);
 
   useEffect(() => {
+    const el = textElementRef.current;
+    if (!el) return;
+
     compareSize();
-  }, [value]);
 
-  // Remove resize listener on component unmount
-  useEffect(
-    () => () => {
-      window.removeEventListener("resize", compareSize);
-    },
-    [],
-  );
-
-  // Define state and function to update the value
-  const [hoverStatus, setHover] = useState(false);
+    const ro = new ResizeObserver(() => {
+      compareSize();
+    });
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, [value, someLongText, ellipsisDirection, compareSize]);
 
   return (
     <Tooltip {...rest} disableHoverListener={!hoverStatus} title={value}>

--- a/packages/open-ui-kit/src/templates/layout/components/layout.tsx
+++ b/packages/open-ui-kit/src/templates/layout/components/layout.tsx
@@ -7,6 +7,7 @@
 import { useEffect, useState } from "react";
 import { Box, Drawer, Toolbar, Typography } from "@mui/material";
 import { Header, HeaderProps } from "@/components";
+import { breakpoints } from "@/theme/common";
 
 export interface LayoutProps {
   content?: React.ReactNode;
@@ -23,10 +24,12 @@ export const Layout = ({
 }: LayoutProps) => {
   const defaultLayoutWidth = 240;
   const collapsedLayoutWidth = 56;
-  const [isCollapsed, setIsCollapsed] = useState(window.innerWidth < 768);
+  const [isCollapsed, setIsCollapsed] = useState(
+    window.innerWidth < (breakpoints.values?.sm ?? 600),
+  );
 
   const handleResize = () => {
-    setIsCollapsed(window.innerWidth < 768);
+    setIsCollapsed(window.innerWidth < (breakpoints.values?.sm ?? 600));
   };
 
   useEffect(() => {

--- a/packages/open-ui-kit/src/templates/layout/components/layout.tsx
+++ b/packages/open-ui-kit/src/templates/layout/components/layout.tsx
@@ -4,10 +4,15 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { useEffect, useState } from "react";
-import { Box, Drawer, Toolbar, Typography } from "@mui/material";
+import {
+  Box,
+  Drawer,
+  Toolbar,
+  Typography,
+  useMediaQuery,
+  useTheme,
+} from "@mui/material";
 import { Header, HeaderProps } from "@/components";
-import { breakpoints } from "@/theme/common";
 
 export interface LayoutProps {
   content?: React.ReactNode;
@@ -22,22 +27,12 @@ export const Layout = ({
   headerProps,
   content,
 }: LayoutProps) => {
+  const theme = useTheme();
   const defaultLayoutWidth = 240;
   const collapsedLayoutWidth = 56;
-  const [isCollapsed, setIsCollapsed] = useState(
-    window.innerWidth < (breakpoints.values?.sm ?? 600),
-  );
-
-  const handleResize = () => {
-    setIsCollapsed(window.innerWidth < (breakpoints.values?.sm ?? 600));
-  };
-
-  useEffect(() => {
-    window.addEventListener("resize", handleResize);
-    return () => {
-      window.removeEventListener("resize", handleResize);
-    };
-  }, []);
+  const isCollapsed = useMediaQuery(theme.breakpoints.down("sm"), {
+    noSsr: true,
+  });
 
   return (
     <Box sx={{ display: "flex" }}>

--- a/packages/open-ui-kit/src/theme/common.tsx
+++ b/packages/open-ui-kit/src/theme/common.tsx
@@ -385,27 +385,39 @@ export const listItemCommonStyles = (theme: Theme) => {
   };
 };
 
+/** Pixel widths for each named breakpoint (required keys; aligns with `BreakpointOverrides` in `types/theme.ts`). */
+export type AppBreakpointValues = {
+  xs: number;
+  sm: number;
+  md: number;
+  lg: number;
+  xl: number;
+  xxl: number;
+};
+
+/** Single source of truth for breakpoint widths (px). Use this instead of `breakpoints.values?.x ?? n`. */
+export const breakpointValues: AppBreakpointValues = {
+  xs: 0,
+  sm: 600,
+  md: 1024,
+  lg: 1440,
+  xl: 1920,
+  xxl: 2560,
+};
+
 export const breakpoints: BreakpointsOptions = {
   keys: ["xs", "sm", "md", "lg", "xl", "xxl"],
-  values: {
-    xs: 0,
-    sm: 600,
-    md: 1024,
-    lg: 1440,
-    xl: 1920,
-    xxl: 2560,
-  },
+  values: breakpointValues,
 };
 
 export const commonMixins = {
   toolbar: {
     minHeight: TOOLBAR_MINIMUM_HEIGHT,
-    [`@media (min-width:${
-      breakpoints.values?.xs ?? 0
-    }px) and (orientation: landscape)`]: {
-      minHeight: TOOLBAR_MINIMUM_HEIGHT,
-    },
-    [`@media (min-width:${breakpoints.values?.sm ?? 600}px)`]: {
+    [`@media (min-width:${breakpointValues.xs}px) and (orientation: landscape)`]:
+      {
+        minHeight: TOOLBAR_MINIMUM_HEIGHT,
+      },
+    [`@media (min-width:${breakpointValues.sm}px)`]: {
       minHeight: TOOLBAR_MINIMUM_HEIGHT,
     },
   },

--- a/packages/open-ui-kit/src/theme/common.tsx
+++ b/packages/open-ui-kit/src/theme/common.tsx
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Components, Theme } from "@mui/material";
+import { BreakpointsOptions, Components, Theme } from "@mui/material";
 import { TypographyVariantsOptions } from "@mui/material/styles/createTypography";
 import { KeyboardArrowUp } from "../custom-icons";
 import { TOOLBAR_MINIMUM_HEIGHT } from "./constants";
@@ -385,13 +385,27 @@ export const listItemCommonStyles = (theme: Theme) => {
   };
 };
 
+export const breakpoints: BreakpointsOptions = {
+  keys: ["xs", "sm", "md", "lg", "xl", "xxl"],
+  values: {
+    xs: 0,
+    sm: 600,
+    md: 1024,
+    lg: 1440,
+    xl: 1920,
+    xxl: 2560,
+  },
+};
+
 export const commonMixins = {
   toolbar: {
     minHeight: TOOLBAR_MINIMUM_HEIGHT,
-    "@media (min-width:0px) and (orientation: landscape)": {
+    [`@media (min-width:${
+      breakpoints.values?.xs ?? 0
+    }px) and (orientation: landscape)`]: {
       minHeight: TOOLBAR_MINIMUM_HEIGHT,
     },
-    "@media (min-width:600px)": {
+    [`@media (min-width:${breakpoints.values?.sm ?? 600}px)`]: {
       minHeight: TOOLBAR_MINIMUM_HEIGHT,
     },
   },

--- a/packages/open-ui-kit/src/theme/dark/dark-theme.tsx
+++ b/packages/open-ui-kit/src/theme/dark/dark-theme.tsx
@@ -14,7 +14,7 @@ import {
   surfaceDark900,
   surfaceDarkPalette,
 } from "../color-palette";
-import { typography, commonMixins } from "../common";
+import { typography, breakpoints, commonMixins } from "../common";
 import {
   createTheme,
   PaletteOptions,
@@ -90,15 +90,7 @@ const palette: PaletteOptions = {
 };
 
 const theme: Theme = createTheme({
-  breakpoints: {
-    keys: ["md", "lg", "xl", "xxl"],
-    values: {
-      md: 1024,
-      lg: 1440,
-      xl: 1920,
-      xxl: 2560,
-    },
-  },
+  breakpoints,
   palette,
   typography,
   mixins: commonMixins,

--- a/packages/open-ui-kit/src/theme/light/light-theme.tsx
+++ b/packages/open-ui-kit/src/theme/light/light-theme.tsx
@@ -27,7 +27,7 @@ import {
   Theme,
   Shadows,
 } from "@mui/material";
-import { commonMixins, typography } from "../common";
+import { commonMixins, typography, breakpoints } from "../common";
 import { lightVars } from "./light-vars";
 import {
   appBarComponent,
@@ -109,15 +109,7 @@ const palette: PaletteOptions = {
 // });
 
 const theme: Theme = createTheme({
-  breakpoints: {
-    keys: ["md", "lg", "xl", "xxl"],
-    values: {
-      md: 1024,
-      lg: 1440,
-      xl: 1920,
-      xxl: 2560,
-    },
-  },
+  breakpoints,
   palette,
   typography,
   mixins: commonMixins,

--- a/packages/open-ui-kit/src/theme/mui/dialog.tsx
+++ b/packages/open-ui-kit/src/theme/mui/dialog.tsx
@@ -15,13 +15,13 @@ export const dialogComponent = (theme: Theme): Components => {
           background: theme.palette.vars.controlBackgroundDefault,
           padding: "24px",
           "&.MuiDialog-paperWidthMd": {
-            maxWidth: "480px",
+            maxWidth: theme.breakpoints.values?.sm ?? 600,
           },
           "&.MuiDialog-paperWidthLg": {
-            maxWidth: "720px",
+            maxWidth: theme.breakpoints.values?.md ?? 1024,
           },
           "&.MuiDialog-paperWidthXl": {
-            maxWidth: "1200px",
+            maxWidth: theme.breakpoints.values?.lg ?? 1440,
           },
         },
       },

--- a/packages/open-ui-kit/src/theme/mui/dialog.tsx
+++ b/packages/open-ui-kit/src/theme/mui/dialog.tsx
@@ -4,7 +4,27 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * Dialog paper `maxWidth` presets vs layout breakpoints
+ * -------------------------------------------------------
+ * MUI’s `maxWidth` string is a **dialog content-size preset**, not `theme.breakpoints.*`.
+ * We map three presets to `breakpointValues` pixel widths so modals stay readable; the
+ * **preset label** (md / lg / xl) does **not** match the **token key** (sm / md / lg).
+ *
+ * | MUI `maxWidth` | Paper `maxWidth` (px) | `breakpointValues` key | Same name as layout breakpoint? |
+ * |----------------|----------------------:|------------------------|--------------------------------|
+ * | `xs`           | *(MUI default)*      | —                      | —                              |
+ * | `sm`           | *(MUI default)*      | —                      | —                              |
+ * | `md`           | 600                   | `sm`                   | **No**                         |
+ * | `lg`           | 1024                  | `md`                   | **No**                         |
+ * | `xl`           | 1440                  | `lg`                   | **No**                         |
+ *
+ * In Storybook, prefer **S / M / L / XL (content)** in titles, not “layout md/lg”.
+ * @see docs/new-breakpoints-branch-changes.md
+ */
+
 import { Components, Theme } from "@mui/material";
+import { breakpointValues } from "../common";
 
 export const dialogComponent = (theme: Theme): Components => {
   return {
@@ -15,13 +35,13 @@ export const dialogComponent = (theme: Theme): Components => {
           background: theme.palette.vars.controlBackgroundDefault,
           padding: "24px",
           "&.MuiDialog-paperWidthMd": {
-            maxWidth: theme.breakpoints.values?.sm ?? 600,
+            maxWidth: breakpointValues.sm,
           },
           "&.MuiDialog-paperWidthLg": {
-            maxWidth: theme.breakpoints.values?.md ?? 1024,
+            maxWidth: breakpointValues.md,
           },
           "&.MuiDialog-paperWidthXl": {
-            maxWidth: theme.breakpoints.values?.lg ?? 1440,
+            maxWidth: breakpointValues.lg,
           },
         },
       },

--- a/packages/open-ui-kit/src/types/theme.ts
+++ b/packages/open-ui-kit/src/types/theme.ts
@@ -33,8 +33,8 @@ declare module "@mui/material/styles" {
   interface PaletteColor extends ColorPartial {}
 
   interface BreakpointOverrides {
-    xs: false;
-    sm: false;
+    xs: true;
+    sm: true;
     md: true;
     lg: true;
     xl: true;


### PR DESCRIPTION
## 📝 Description

This PR tightens **responsive behavior** and **breakpoint handling** across the kit:

- **Theme:** Introduces **`AppBreakpointValues`** and a single **`breakpointValues`** object (required keys) as the source of truth for pixel widths, passed into MUI `breakpoints` and used in mixins/dialog overrides without `??` fallbacks. Documents how **Dialog `maxWidth` presets** map to those tokens (preset names ≠ layout breakpoint names).
- **Layout template:** Replaces `window.innerWidth`, `useState`, and **`window` `resize`** with **`useTheme()` + `useMediaQuery(theme.breakpoints.down("sm"), { noSsr: true })`** so sidenav collapse matches the theme and avoids SSR `window` access.
- **Charts / overflow UI:** Replaces **`window` `resize`** with **`ResizeObserver`** on the relevant DOM nodes in **`BarGraph`** (Y-axis width vs container) and **`OverflowTooltip`** (text overflow vs wrapper). Fixes **Rules of Hooks** in `OverflowTooltip` by declaring state before effects.
- **Storybook:** Updates **Modal** stories and `argTypes` to describe **content widths (M/L/XL)** vs **layout** breakpoints and points readers to the theme docblock.

**Commits (newest last):**

1. `refactor(theme): typed breakpointValues and dialog maxWidth mapping docs`
2. `fix(layout): use useMediaQuery for sidenav collapse instead of window resize`
3. `refactor: use ResizeObserver instead of window resize in bar-graph and overflow-tooltip`
4. `docs(storybook): clarify modal content widths vs layout breakpoints`

## 🔗 Related Issue

-

## 🧪 Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue) — Layout SSR-safe collapse; `OverflowTooltip` hook order
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 💥 Breaking change: Existing checks for sm and xs breakpoints were ignored up until now. Now they are activated by introducing these breakpoints.
- [x] 📚 Documentation update — Storybook + JSDoc on `dialog.tsx`
- [ ] 🎨 Style/design update
- [ ] 🔧 Build/CI update
- [x] ♻️ Refactoring — ResizeObserver; typed `breakpointValues`
- [ ] 🧪 Tests only

## 🧪 Testing

- [ ] Unit tests pass (`yarn test`) — *confirm in CI / locally; `@open-ui-kit/core` may report no unit tests*
- [ ] Storybook builds successfully (`yarn storybook`)
- [x] Manual testing completed — *recommended: resize window, open Modal sizes story, overflow + bar chart layouts*
- [ ] Cross-browser testing (if applicable)

**Test Instructions:**

1. Run `yarn turbo run lint --filter=@open-ui-kit/core` (or repo lint) and ensure it passes.
2. **Layout:** Open a story or playground using **`Layout`**; resize below/above **600px** (`sm`); sidenav should collapse/expand; reload on narrow viewport and check for a possible brief flash (`noSsr`).
3. **Modal:** In Storybook **Components → Modal → Dialog sizes (content width)**, open each dialog and confirm paper widths match the documented mapping (e.g. `maxWidth="md"` → 600px paper from `breakpointValues.sm`).
4. **OverflowTooltip:** Long text in a narrow container; tooltip only when truncated; resize container/window and confirm behavior updates.
5. **BarGraph:** Resize parent/container; Y-axis header width should track (~43% of container) without relying on `window` resize only.

## ♿ Accessibility

- [x] Follows WCAG 2.1 AA guidelines — *no intentional regression; verify Modal focus/labels unchanged*
- [ ] Keyboard navigation tested
- [ ] Screen reader tested
- [ ] Color contrast verified
- [ ] Focus indicators present
- [ ] ARIA attributes added where needed

## 📱 Responsive Design

- [x] Mobile responsive — *Layout `down(sm)`; Modal story documents content widths*
- [x] Tablet responsive — *breakpoint scale unchanged (e.g. `sm` 600, `md` 1024)*
- [x] Desktop responsive
- [ ] All breakpoints tested — *spot-check `sm` / `md` boundaries*

## 📚 Documentation

- [x] Storybook story added/updated — **Modal** sizes story + `maxWidth` description
- [ ] Component props documented
- [x] Usage examples provided — *via Storybook story copy*
- [ ] README updated (if needed)
- [x] TypeScript types exported — **`AppBreakpointValues`**, **`breakpointValues`** from `theme/common.tsx` (consumers importing `@/theme/common`)

## 🔄 Breaking Changes

- [x] This PR introduces breaking changes — *no public API removals; `Modal`/`Dialog` signatures unchanged*
- [ ] Migration guide provided (if breaking changes)
- [ ] Version bump required

**Behavioral notes (non-breaking but worth release notes):**

- **Layout:** First client paint may briefly differ from SSR for sidenav collapse (`useMediaQuery` + `noSsr: true`).
- **BarGraph / OverflowTooltip:** Size updates follow **element** resize (ResizeObserver), not only viewport resize.
- **Dialog:** Preset → pixel mapping is **documented**; names still differ from layout breakpoint labels by design.

## 📋 Checklist

- [x] Code follows the project's style guidelines
- [ ] Self-review of code completed
- [x] Code is commented where necessary — *`dialog.tsx` JSDoc table*
- [x] No console.log statements left in code
- [ ] Build passes locally
- [ ] Tests added for new functionality
- [ ] Existing tests still pass
- [x] No TypeScript errors — *full-package `tsc` may have pre-existing issues outside this PR*
- [ ] No accessibility violations
- [x] PR title follows [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/) — *e.g. `feat`/`fix`/`refactor` scope as appropriate*

## 📸 Screenshots
-

---

**For Maintainers:**

- [ ] Ready for review
- [ ] Requires design review
- [ ] Requires accessibility review
- [ ] Ready to merge
