### PR TITLE
docs: deep link component storybook buttons

### DIFF
--- a/docs/data/material/pages.ts
+++ b/docs/data/material/pages.ts
@@ -66,7 +66,7 @@ const pages: MuiPage[] = [
     ],
   },
   {
-    pathname: "/storybook",
+    pathname: "/storybook/",
     title: "Storybook",
     icon: standardNavIcons.WebIcon,
     linkProps: {

--- a/docs/pages/index.tsx
+++ b/docs/pages/index.tsx
@@ -148,7 +148,7 @@ export default function HomePage() {
             {[
               ["Docs", "/open-ui-kit-core/"],
               ["Components", "/open-ui-kit-core/all-components/"],
-              ["Storybook", "/storybook"],
+              ["Storybook", "/storybook/"],
             ].map(([label, href]) => {
               const isExternal = href.startsWith("http");
 

--- a/docs/src/layouts/AppFooter.tsx
+++ b/docs/src/layouts/AppFooter.tsx
@@ -17,7 +17,7 @@ const footerGroups = [
       { label: "Components", href: "/open-ui-kit-core/all-components/" },
       {
         label: "Storybook",
-        href: "/storybook",
+        href: "/storybook/",
       },
     ],
   },
@@ -47,7 +47,7 @@ const footerGroups = [
       { label: "Text Field", href: "/open-ui-kit-core/react-text-field/" },
       {
         label: "Storybook",
-        href: "/storybook",
+        href: "/storybook/",
       },
     ],
   },

--- a/docs/src/open-ui-kit-component-registry.ts
+++ b/docs/src/open-ui-kit-component-registry.ts
@@ -21,7 +21,7 @@ export type OpenUIKitComponentDoc = {
   title: string;
 };
 
-const storybookBaseUrl = "/storybook";
+const storybookBaseUrl = "/storybook/";
 const packageSourceUrl =
   "https://github.com/outshift-open/open-ui-kit/tree/main/packages/open-ui-kit/src";
 const packageBarrelUrl =
@@ -948,5 +948,5 @@ export function getOpenUIKitStorybookUrl(component: OpenUIKitComponentDoc) {
     .replace(/[^a-z0-9]+/g, "-")
     .replace(/^-|-$/g, "");
 
-  return `${storybookBaseUrl}/?path=/docs/${storybookId}--docs`;
+  return `${storybookBaseUrl}?path=/docs/${storybookId}--docs`;
 }

--- a/docs/vendor/mui-internal-core-docs/src/ComponentLinkHeader/ComponentLinkHeader.tsx
+++ b/docs/vendor/mui-internal-core-docs/src/ComponentLinkHeader/ComponentLinkHeader.tsx
@@ -6,6 +6,10 @@ import GitHubIcon from "@mui/icons-material/GitHub";
 import Inventory2RoundedIcon from "@mui/icons-material/Inventory2Rounded";
 import { styled } from "@mui/material/styles";
 import { type MarkdownHeaders } from "@mui/internal-markdown";
+import {
+  getOpenUIKitComponentByRouteSlug,
+  getOpenUIKitStorybookUrl,
+} from "docs/src/open-ui-kit-component-registry";
 import { W3CIcon, MarkdownIcon, StorybookIcon } from "../svgIcons";
 import { useTranslate } from "../i18n";
 
@@ -53,7 +57,25 @@ const defaultPackageNames: Record<string, string | undefined> = {
   system: "@mui/system",
 };
 
-const STORYBOOK_URL = "/storybook";
+const STORYBOOK_URL = "/storybook/";
+
+function getStorybookUrlFromRoute(asPath: string) {
+  const routeSlug = asPath
+    .split("?")[0]
+    .split("#")[0]
+    .replace(/\/$/, "")
+    .split("/")
+    .pop()
+    ?.replace(/^react-/, "");
+
+  if (!routeSlug) {
+    return STORYBOOK_URL;
+  }
+
+  const component = getOpenUIKitComponentByRouteSlug(routeSlug);
+
+  return component ? getOpenUIKitStorybookUrl(component) : STORYBOOK_URL;
+}
 
 export interface ComponentLinkHeaderProps {
   design?: boolean;
@@ -69,6 +91,7 @@ export function ComponentLinkHeader(props: ComponentLinkHeaderProps) {
   } = props;
   const t = useTranslate();
   const router = useRouter();
+  const storybookHref = getStorybookUrlFromRoute(router.asPath);
 
   const packageName =
     headers.packageName ??
@@ -105,7 +128,7 @@ export function ComponentLinkHeader(props: ComponentLinkHeaderProps) {
           variant="outlined"
           target="_blank"
           rel="noopener noreferrer"
-          href={STORYBOOK_URL}
+          href={storybookHref}
           icon={<StorybookIcon />}
           label="Storybook"
         />

--- a/docs/vendor/mui-internal-core-docs/src/constants/route.ts
+++ b/docs/vendor/mui-internal-core-docs/src/constants/route.ts
@@ -5,7 +5,7 @@ export const ROUTES = {
   components: "/open-ui-kit-core/all-components/",
   support: "/open-ui-kit-core/getting-started/support/",
   versions: "/open-ui-kit-core/getting-started/versions/",
-  storybook: "/storybook",
+  storybook: "/storybook/",
   repository: "https://github.com/outshift-open/open-ui-kit",
   privacyPolicy: "https://github.com/outshift-open/open-ui-kit",
 };


### PR DESCRIPTION
## 📝 Description

Fixes the Storybook link shown in component docs pages.

Previously, the shared component docs header always linked to `/storybook/`, which opened Storybook on the default overview page. This update makes the Storybook chip resolve the current component route and deep-link to the matching Storybook docs page, for example:

`/storybook/?path=/docs/components-button--docs`

Also normalizes docs Storybook entry links to use `/storybook/`.

## 🔗 Related Issue

Closes #

## 🧪 Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 📚 Documentation update
- [ ] 🎨 Style/design update
- [ ] 🔧 Build/CI update
- [ ] ♻️ Refactoring (no functional changes)
- [ ] 🧪 Tests only

## 🧪 Testing

- [ ] Focused tests pass (`yarn test --testPathPattern=<component-or-area>`)
- [ ] Lint and typecheck pass (`yarn lint && yarn typecheck`)
- [ ] Storybook builds successfully (`yarn storybook:build`)
- [x] Manual testing completed
- [ ] Cross-browser testing (if applicable)

**Test Instructions:**

1. Open a component docs page, for example `/open-ui-kit-core/react-button/`.
2. Click the Storybook chip in the component header.
3. Confirm it opens the matching Storybook docs page:
   `/storybook/?path=/docs/components-button--docs`
4. Spot-check another component such as Footer, Layout, or ActionsDialog.

Validated locally:

- `yarn typecheck`
- `yarn docs:build`
- Checked exported HTML for Button, Footer, Layout, and ActionsDialog Storybook links.

## ♿ Accessibility

- [ ] Follows WCAG 2.1 AA guidelines
- [ ] Keyboard navigation tested
- [ ] Screen reader tested
- [ ] Color contrast verified
- [ ] Focus indicators present
- [ ] ARIA attributes added where needed

## 📱 Responsive Design

- [ ] Mobile responsive
- [ ] Tablet responsive
- [ ] Desktop responsive
- [ ] All breakpoints tested

## 📚 Documentation

- [ ] Storybook story added/updated
- [ ] Component props documented
- [ ] Usage examples provided
- [ ] README updated (if needed)
- [ ] TypeScript types exported

## 🔄 Breaking Changes

- [ ] This PR introduces breaking changes
- [ ] Migration guide provided (if breaking changes)
- [ ] Version bump required

## 📋 Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code completed
- [ ] Code is commented where necessary
- [x] No console.log statements left in code
- [x] Build passes locally
- [ ] Tests added for new functionality
- [x] Existing tests still pass
- [x] No TypeScript errors
- [ ] No accessibility violations
- [x] Full unscoped `yarn test` was not run locally
- [x] PR title follows [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/)

## 📸 Screenshots

### Before

Component docs Storybook chip opened the default Storybook overview page.

### After

Component docs Storybook chip opens the matching component Storybook docs page.

## 🔍 Additional Notes

This is a follow-up to the docs-hosted Storybook route work. It fixes component-level deep links now that Storybook is served from `/storybook/`.

---

**For Maintainers:**
- [x] Ready for review
- [ ] Requires design review
- [ ] Requires accessibility review
- [ ] Ready to merge