### PR TITLE
fix(release): use npm trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 22.14.0
           cache: yarn
 
       - name: Install dependencies
@@ -60,8 +60,6 @@ jobs:
       - name: Release
         env:
           GITHUB_TOKEN: ${{ secrets.SEMANTIC_RELEASE_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           GIT_AUTHOR_NAME: semantic-release-bot
           GIT_AUTHOR_EMAIL: semantic-release-bot@users.noreply.github.com
           GIT_COMMITTER_NAME: semantic-release-bot


### PR DESCRIPTION
## Summary

- Switches npm publishing to Trusted Publishing/OIDC by removing `NPM_TOKEN` and `NODE_AUTH_TOKEN` from the release step.
- Keeps `id-token: write` so `@semantic-release/npm` can exchange the GitHub Actions OIDC identity with npm.
- Pins the release workflow to Node `22.14.0`, matching npm Trusted Publishing runtime requirements.

## Release impact

This PR intentionally uses a `fix(release)` conventional title/commit so merging it to `main` will trigger a patch release and verify the new npm Trusted Publishing path.

## npm setup

Trusted Publisher is configured on npm for:

- Package: `@open-ui-kit/core`
- Repository: `outshift-open/open-ui-kit`
- Workflow: `release.yml`
- Permission: `npm publish`

## Validation

- Inspected `.github/workflows/release.yml` for OIDC permission and removal of npm token env vars.
- `git diff --check`
