### PR TITLE
ci: sync beta after main release

### DIFF
--- a/.github/workflows/sync-beta.yml
+++ b/.github/workflows/sync-beta.yml
@@ -1,0 +1,44 @@
+name: Sync Beta
+
+on:
+  workflow_dispatch:
+  workflow_run:
+    workflows:
+      - Release
+    types:
+      - completed
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+concurrency:
+  group: sync-beta
+  cancel-in-progress: false
+
+jobs:
+  sync-beta:
+    name: Sync beta from main
+    if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    env:
+      HUSKY: 0
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          ref: main
+          token: ${{ secrets.SEMANTIC_RELEASE_TOKEN }}
+
+      - name: Fast-forward beta
+        run: |
+          git fetch origin beta
+
+          if ! git merge-base --is-ancestor origin/beta origin/main; then
+            echo "beta has commits that are not in main; refusing to overwrite it."
+            exit 1
+          fi
+
+          git push origin origin/main:beta


### PR DESCRIPTION
## Summary

- Adds a `Sync Beta` GitHub Actions workflow.
- Runs after the `Release` workflow completes successfully on `main`, plus manual `workflow_dispatch`.
- Fast-forwards `beta` to `main` using the existing `SEMANTIC_RELEASE_TOKEN`.
- Refuses to overwrite `beta` if it has commits that are not already in `main`.

## Why

If a PR is merged directly into `main`, `beta` should automatically catch up without manually deleting or recreating the branch. Since `beta` is protected and deletions are disabled, this keeps it persistent while still following released `main`.

## Validation

- Inspected workflow syntax and trigger behavior.
- `git diff --check`
