### PR TITLE
ci: fix release branch checkout

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,12 +32,12 @@ jobs:
         uses: actions/checkout@v7
         with:
           fetch-depth: 0
-          ref: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || github.ref_name }}
+          ref: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_branch || github.ref_name }}
           token: ${{ secrets.SEMANTIC_RELEASE_TOKEN }}
 
-      - name: Restore release branch context
+      - name: Verify release branch context
         if: github.event_name == 'workflow_run'
-        run: git checkout -B "${{ github.event.workflow_run.head_branch }}" "${{ github.event.workflow_run.head_sha }}"
+        run: test "$(git rev-parse HEAD)" = "${{ github.event.workflow_run.head_sha }}"
 
       - name: Enable Corepack
         run: corepack enable


### PR DESCRIPTION
## Summary
- Check out the completed CI branch for workflow_run release jobs instead of the raw commit SHA
- Verify the checked-out branch still points at the CI-tested SHA before releasing
- Fix semantic-release failing with `fatal: malformed object name main`

## Testing
- git diff --check HEAD~1..HEAD